### PR TITLE
Use loggly bulk API

### DIFF
--- a/lib/logstash/outputs/loggly.rb
+++ b/lib/logstash/outputs/loggly.rb
@@ -136,7 +136,7 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
     event.to_json
   end
 
-  def flush(events, teardown=false)
+  def flush(events, close=false)
     # Avoid creating a new string for newline every time
     newline = "\n".freeze
 
@@ -220,8 +220,8 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
     end #loop
   end # def send_event
 
-  def teardown
+  def close
     buffer_flush(:final => true)
-  end # def teardown
+  end # def close
 
 end # class LogStash::Outputs::Loggly

--- a/lib/logstash/outputs/loggly.rb
+++ b/lib/logstash/outputs/loggly.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/outputs/base"
 require "logstash/namespace"
+require "stud/buffer"
 require "uri"
 # TODO(sissel): Move to something that performs better than net/http
 require "net/http"
@@ -26,6 +27,8 @@ end
 # To use this, you'll need to use a Loggly input with type 'http'
 # and 'json logging' enabled.
 class LogStash::Outputs::Loggly < LogStash::Outputs::Base
+  include Stud::Buffer
+
   config_name "loggly"
 
   # The hostname to send logs to. This should target the loggly http input
@@ -81,6 +84,23 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
   # Proxy Password
   config :proxy_password, :validate => :password, :default => ""
 
+  # This plugin uses the bulk index api for improved indexing performance.
+  # To make efficient bulk api calls, we will buffer a certain number of
+  # events before flushing that out to Loggly. This setting
+  # controls how many events will be buffered before sending a batch
+  # of events.
+  config :flush_size, :validate => :number, :default => 100
+
+  # The amount of time since last flush before a flush is forced.
+  #
+  # This setting helps ensure slow event rates don't get stuck in Logstash.
+  # For example, if your `flush_size` is 100, and you have received 10 events,
+  # and it has been more than `idle_flush_time` seconds since the last flush,
+  # logstash will flush those 10 events automatically.
+  #
+  # This helps keep both fast and slow log streams moving along in
+  # near-real-time.
+  config :idle_flush_time, :validate => :number, :default => 1
 
   # HTTP constants
   HTTP_SUCCESS = "200"
@@ -91,12 +111,16 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
 
   public
   def register
-    # nothing to do
+    buffer_initialize(
+      :max_items => @flush_size,
+      :max_interval => @idle_flush_time,
+      :logger => @logger
+    )
   end
 
   public
   def receive(event)
-
+    return unless output?(event)
     key = event.sprintf(@key)
     tag = event.sprintf(@tag)
 
@@ -104,14 +128,25 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
     # we should ship logs with the default tag value.
     tag = 'logstash' if /^%{\w+}/.match(tag)
 
-    # Send event
-    send_event("#{@proto}://#{@host}/inputs/#{key}/tag/#{tag}", format_message(event))
+    buffer_receive([event, key, tag])
   end # def receive
 
   public
   def format_message(event)
     event.to_json
   end
+
+  def flush(events, teardown=false)
+    # Avoid creating a new string for newline every time
+    newline = "\n".freeze
+
+    body = events.collect do |event, key, tag|
+      [ format_message(event), newline ]
+    end.flatten
+
+    send_event("#{@proto}://#{@host}/bulk/#{@key}/tag/#{@tag}", body.join(""))
+  end # def receive_bulk
+
 
   private
   def send_event(url, message)
@@ -144,9 +179,10 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
       begin
         response = http.request(request)
         case response.code
+
           # HTTP_SUCCESS :Code 2xx
           when HTTP_SUCCESS
-            puts "Event send to Loggly"
+            @logger.info("Event send to Loggly")
 
           # HTTP_FORBIDDEN :Code 403
           when HTTP_FORBIDDEN
@@ -154,7 +190,7 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
 
           # HTTP_NOT_FOUND :Code 404
           when HTTP_NOT_FOUND
-            @logger.warn("Invalid URL. Please check URL should be http://logs-01.loggly.com/inputs/CUSTOMER_TOKEN/tag/logstash")
+            @logger.warn("Invalid URL. Please check URL should be http://logs-01.loggly.com/bulk/CUSTOMER_TOKEN/tag/logstash")
 
           # HTTP_INTERNAL_SERVER_ERROR :Code 500
           when HTTP_INTERNAL_SERVER_ERROR
@@ -167,12 +203,13 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
             @logger.error("Unexpected response code", :code => response.code)
         end # case
 
-        if [HTTP_SUCCESS,HTTP_FORBIDDEN,HTTP_NOT_FOUND].include?(response.code) # break the retries loop for the specified response code
+        if [HTTP_SUCCESS,HTTP_FORBIDDEN,HTTP_NOT_FOUND].include?(response.code)   # break the retries loop for the specified response code
           break
         end
+
       rescue StandardError => e
         @logger.error("An unexpected error occurred", :exception => e.class.name, :error => e.to_s, :backtrace => e.backtrace)
-      end # begin
+      end # rescue
 
       if totalRetries < @retry_count && totalRetries > 0
         puts "Waiting for five seconds before retry..."
@@ -180,6 +217,11 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
       end
 
       totalRetries = totalRetries + 1
-    end # loop
+    end #loop
   end # def send_event
+
+  def teardown
+    buffer_flush(:final => true)
+  end # def teardown
+
 end # class LogStash::Outputs::Loggly


### PR DESCRIPTION
See https://www.loggly.com/docs/http-bulk-endpoint/

With the bulk API and some tweaking on the number of output workers and the flush size, the speed increased by around 50 times on my setup.
