### PR TITLE
Add Loggly supported timestamp field

### DIFF
--- a/lib/logstash/outputs/loggly.rb
+++ b/lib/logstash/outputs/loggly.rb
@@ -121,8 +121,8 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
 
     if event.include?("@timestamp")
         timestamp = event.remove("@timestamp")
-        # An existing timestamp field sould be left untouched
-        event["timestamp"] = timestamp unless event.include?("timestamp")
+        # An existing timestamp field should be left untouched
+        event.set("timestamp", timestamp) unless event.include?("timestamp")
     end
   end
 

--- a/lib/logstash/outputs/loggly.rb
+++ b/lib/logstash/outputs/loggly.rb
@@ -59,7 +59,7 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
   # https://www.loggly.com/docs/source-groups/
   config :tag, :validate => :string, :default => "logstash"
 
-  # Retry count. 
+  # Retry count.
   # It may be possible that the request may timeout due to slow Internet connection
   # if such condition appears, retry_count helps in retrying request for multiple times
   # It will try to submit request until retry_count and then halt
@@ -80,7 +80,6 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
 
   # Proxy Password
   config :proxy_password, :validate => :password, :default => ""
-
 
   # HTTP constants
   HTTP_SUCCESS = "200"
@@ -103,6 +102,9 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
     # we should ship logs with the default tag value.
     tag = 'logstash' if /^%{\w+}/.match(tag)
 
+    # Transform @timestamp to Loggly's JSON timestamp field
+    transform_ts(event)
+
     # Send event
     send_event("#{@proto}://#{@host}/inputs/#{key}/tag/#{tag}", format_message(event))
   end # def receive
@@ -113,6 +115,17 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
   end
 
   private
+  def transform_ts(event)
+    # Transform default event @timestamp field to a Loggly JSON timestamp field.
+    # See https://www.loggly.com/docs/automated-parsing/#json
+
+    if event.include?("@timestamp")
+        timestamp = event.remove("@timestamp")
+        # An existing timestamp field sould be left untouched
+        event["timestamp"] = timestamp unless event.include?("timestamp")
+    end
+  end
+
   def send_event(url, message)
     url = URI.parse(url)
     @logger.info("Loggly URL", :url => url)
@@ -138,30 +151,30 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
       @retry_count = 1
     end
 
-    
+
     @retry_count.times do
     begin
-      response = http.request(request)	
+      response = http.request(request)
       case response.code
-	  
+
 	    # HTTP_SUCCESS :Code 2xx
-	    when HTTP_SUCCESS					
+	    when HTTP_SUCCESS
 	      puts "Event send to Loggly"
-		  
+
 		# HTTP_FORBIDDEN :Code 403
-	    when HTTP_FORBIDDEN					
+	    when HTTP_FORBIDDEN
 	      @logger.warn("User does not have privileges to execute the action.")
-		
+
 		# HTTP_NOT_FOUND :Code 404
-	    when HTTP_NOT_FOUND					
+	    when HTTP_NOT_FOUND
 	      @logger.warn("Invalid URL. Please check URL should be http://logs-01.loggly.com/inputs/CUSTOMER_TOKEN/tag/logstash")
-	    
+
 		# HTTP_INTERNAL_SERVER_ERROR :Code 500
-		when HTTP_INTERNAL_SERVER_ERROR			
+		when HTTP_INTERNAL_SERVER_ERROR
 	      @logger.warn("Internal Server Error")
-		
+
 		# HTTP_GATEWAY_TIMEOUT :Code 504
-	    when HTTP_GATEWAY_TIMEOUT				
+	    when HTTP_GATEWAY_TIMEOUT
 	      @logger.warn("Gateway Time Out")
 	    else
 	      @logger.error("Unexpected response code", :code => response.code)
@@ -173,12 +186,12 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
 	  rescue StandardError => e
         @logger.error("An unexpected error occurred", :exception => e.class.name, :error => e.to_s, :backtrace => e.backtrace)
       end # rescue
-     
+
       if totalRetries < @retry_count && totalRetries > 0
         puts "Waiting for five seconds before retry..."
         sleep(5)
       end
-	  
+
       totalRetries = totalRetries + 1
     end #loop
   end # def send_event

--- a/spec/outputs/loggly_spec.rb
+++ b/spec/outputs/loggly_spec.rb
@@ -7,10 +7,19 @@ describe 'outputs/loggly' do
 
   let(:event) do
     LogStash::Event.new(
-      'message' => 'fanastic log entry',
-      'source' => 'someapp',
-      'type' => 'nginx',
-      '@timestamp' => LogStash::Timestamp.now)
+      "message" => "fanastic log entry",
+      "source" => "someapp",
+      "type" => "nginx",
+      "@timestamp" => LogStash::Timestamp.now
+    )
+  end
+
+  let(:loggly_formatted_event) do
+      # Loggly output plugin replaces the default @timestamp field
+      #  with Loggly's expected timestamp field (i.e timestamp).
+      timestamp = event.remove("@timestamp")
+      event["timestamp"] = timestamp
+      event
   end
 
   context 'when initializing' do
@@ -32,25 +41,24 @@ describe 'outputs/loggly' do
       # add a custom key value for Loggly config
       event.set('token', 'xxxxxxx1234567')
       config['key'] = '%{token}'
-
       output = LogStash::Outputs::Loggly.new(config)
       allow(output).to receive(:send_event).with('http://logs-01.loggly.com/inputs/xxxxxxx1234567/tag/logstash',
-                                                 event.to_json)
+                                                 loggly_formatted_event.to_json)
       output.receive(event)
     end
 
     it 'should set the default tag to logstash' do
       output = LogStash::Outputs::Loggly.new(config)
       allow(output).to receive(:send_event).with('http://logs-01.loggly.com/inputs/abcdef123456/tag/logstash',
-                                                 event.to_json)
+                                                 loggly_formatted_event.to_json)
       output.receive(event)
     end
 
     it 'should support field interpolation for tag' do
-      config['tag'] = '%{source}'
+      config['tag'] = "%{source}"
       output = LogStash::Outputs::Loggly.new(config)
       allow(output).to receive(:send_event).with('http://logs-01.loggly.com/inputs/abcdef123456/tag/someapp',
-                                                 event.to_json)
+                                                 loggly_formatted_event.to_json)
       output.receive(event)
     end
 
@@ -58,7 +66,33 @@ describe 'outputs/loggly' do
       config['tag'] = '%{foobar}'
       output = LogStash::Outputs::Loggly.new(config)
       allow(output).to receive(:send_event).with('http://logs-01.loggly.com/inputs/abcdef123456/tag/logstash',
-                                                 event.to_json)
+                                                 loggly_formatted_event.to_json)
+      output.receive(event)
+    end
+  end
+
+  context 'when transforming @timestamp' do
+    it 'should replace the field named @timestamp with timestamp' do
+      output = LogStash::Outputs::Loggly.new(config)
+      allow(output).to receive(:send_event).with('http://logs-01.loggly.com/inputs/abcdef123456/tag/logstash',
+                                                 loggly_formatted_event.to_json)
+      output.receive(event)
+    end
+
+    it 'should not modify timestamp if @timestamp was renamed via Logstash (i.e mutate replace)' do
+      output = LogStash::Outputs::Loggly.new(config)
+      allow(output).to receive(:send_event).with('http://logs-01.loggly.com/inputs/abcdef123456/tag/logstash',
+                                                 loggly_formatted_event.to_json)
+
+      output.receive(loggly_formatted_event)
+    end
+
+    it 'should only remove @timestamp if both @timestamp and timestamp fields exists (i.e mutate add_field)' do
+      output = LogStash::Outputs::Loggly.new(config)
+      allow(output).to receive(:send_event).with('http://logs-01.loggly.com/inputs/abcdef123456/tag/logstash',
+                                                 loggly_formatted_event.to_json)
+
+      event["timestamp"] = event["@timestamp"]
       output.receive(event)
     end
   end

--- a/spec/outputs/loggly_spec.rb
+++ b/spec/outputs/loggly_spec.rb
@@ -19,7 +19,7 @@ describe 'outputs/loggly' do
     #  with Loggly's expected timestamp field (i.e timestamp).
     formatted_event = event.clone
     timestamp = formatted_event.remove("@timestamp")
-    formatted_event["timestamp"] = timestamp
+    formatted_event.set("timestamp", timestamp)
     formatted_event
   end
 
@@ -93,7 +93,7 @@ describe 'outputs/loggly' do
       allow(output).to receive(:send_event).with('http://logs-01.loggly.com/inputs/abcdef123456/tag/logstash',
                                                  loggly_formatted_event.to_json)
 
-      event["timestamp"] = event["@timestamp"]
+      event.set("timestamp", event.get("@timestamp"))
       output.receive(event)
     end
   end

--- a/spec/outputs/loggly_spec.rb
+++ b/spec/outputs/loggly_spec.rb
@@ -15,11 +15,12 @@ describe 'outputs/loggly' do
   end
 
   let(:loggly_formatted_event) do
-      # Loggly output plugin replaces the default @timestamp field
-      #  with Loggly's expected timestamp field (i.e timestamp).
-      timestamp = event.remove("@timestamp")
-      event["timestamp"] = timestamp
-      event
+    # Loggly output plugin replaces the default @timestamp field
+    #  with Loggly's expected timestamp field (i.e timestamp).
+    formatted_event = event.clone
+    timestamp = formatted_event.remove("@timestamp")
+    formatted_event["timestamp"] = timestamp
+    formatted_event
   end
 
   context 'when initializing' do


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

In order for Loggly to parse timestamps for a given log event the
timestamp data must be contained in a timestamp field - not @timestamp.
This change replaces the default @timestamp field of an event with a
timestamp field before posting to Loggly; Addressing Github Issue #12
