### PR TITLE
Use Timeout.timeout instead of timeout

### DIFF
--- a/lib/logstash/outputs/loggly.rb
+++ b/lib/logstash/outputs/loggly.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/outputs/base"
 require "logstash/namespace"
+require "timeout"
 require "uri"
 # TODO(sissel): Move to something that performs better than net/http
 require "net/http"
@@ -12,7 +13,7 @@ Net::BufferedIO.class_eval do
     BUFSIZE = 1024 * 16
 
     def rbuf_fill
-      timeout(@read_timeout) {
+      ::Timeout.timeout(@read_timeout) {
         @rbuf << @io.sysread(BUFSIZE)
       }
     end


### PR DESCRIPTION
Removes annoying timeout deprecation warning on every call to Loggly.

```
Event send to Loggly
[2018-04-27T15:44:10,281][INFO ][logstash.outputs.loggly  ] Loggly URL {:url=>#<URI::HTTPS https://logs-01.loggly.com/inputs/af3065a5-82b3-4cd5-999c-070d7b21b11f/tag/platform,logstash>}
/usr/share/logstash/vendor/bundle/jruby/2.3.0/gems/logstash-output-loggly-3.0.4/lib/logstash/outputs/loggly.rb:15: warning: Object#timeout is deprecated, use Timeout.timeout instead
```