### PR TITLE
A small cleanup turned into a sizeable one...

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -81,13 +81,9 @@ https://www.loggly.com/docs/http-endpoint/
   * Value type is <<string,string>>
   * There is no default value for this setting.
 
-The loggly http input key to send to.
-This is usually visible in the Loggly 'Inputs' page as something like this:
-....
-    https://logs-01.loggly.net/inputs/abcdef12-3456-7890-abcd-ef0123456789
-                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                                          \---------->   key   <-------------/
-....
+The loggly http customer token to use for sending.
+You can find yours in "Source Setup", under "Customer Tokens".
+
 You can use `%{foo}` field lookups here if you need to pull the api key from
 the event. This is mainly aimed at multitenant hosting providers who want
 to offer shipping a customer's logs to that customer's loggly account.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -21,7 +21,6 @@ include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
-Ugly monkey patch to get around http://jira.codehaus.org/browse/JRUBY-5529
 Got a loggly account? Use logstash to ship logs to Loggly!
 
 This is most useful so you can use logstash to parse and structure

--- a/lib/logstash/outputs/loggly.rb
+++ b/lib/logstash/outputs/loggly.rb
@@ -35,13 +35,9 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
   # https://www.loggly.com/docs/http-endpoint/
   config :host, :validate => :string, :default => "logs-01.loggly.com"
 
-  # The loggly http input key to send to.
-  # This is usually visible in the Loggly 'Inputs' page as something like this:
-  # ....
-  #     https://logs-01.loggly.net/inputs/abcdef12-3456-7890-abcd-ef0123456789
-  #                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  #                                           \---------->   key   <-------------/
-  # ....
+  # The loggly http customer token to use for sending.
+  # You can find yours in "Source Setup", under "Customer Tokens".
+  #
   # You can use `%{foo}` field lookups here if you need to pull the api key from
   # the event. This is mainly aimed at multitenant hosting providers who want
   # to offer shipping a customer's logs to that customer's loggly account.
@@ -116,7 +112,7 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
   private
   def send_event(url, message)
     url = URI.parse(url)
-    @logger.info("Loggly URL", :url => url)
+    @logger.debug("Loggly URL", :url => url)
 
     http = Net::HTTP::Proxy(@proxy_host,
                             @proxy_port,
@@ -128,7 +124,7 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
     end
 
-    request = Net::HTTP::Post.new(url.path)
+    request = Net::HTTP::Post.new(url.path, {'Content-Type' =>'application/json'})
     request.body = message
 
     # Variable for count total retries

--- a/lib/logstash/outputs/loggly.rb
+++ b/lib/logstash/outputs/loggly.rb
@@ -147,7 +147,7 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
 
           # HTTP_SUCCESS :Code 2xx
         when HTTP_SUCCESS
-          puts "Event send to Loggly"
+          puts "Event sent to Loggly"
 
           # HTTP_FORBIDDEN :Code 403
         when HTTP_FORBIDDEN

--- a/lib/logstash/outputs/loggly.rb
+++ b/lib/logstash/outputs/loggly.rb
@@ -147,7 +147,7 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
 
           # HTTP_SUCCESS :Code 2xx
         when HTTP_SUCCESS
-          puts "Event sent to Loggly"
+          @logger.debug("Event sent to Loggly")
 
           # HTTP_FORBIDDEN :Code 403
         when HTTP_FORBIDDEN

--- a/lib/logstash/outputs/loggly.rb
+++ b/lib/logstash/outputs/loggly.rb
@@ -176,7 +176,7 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
       end # rescue
 
       if totalRetries < @retry_count && totalRetries > 0
-        puts "Waiting for five seconds before retry..."
+        @logger.warn "Waiting for five seconds before retry..."
         sleep(5)
       end
 

--- a/lib/logstash/outputs/loggly.rb
+++ b/lib/logstash/outputs/loggly.rb
@@ -139,47 +139,47 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
       @retry_count = 1
     end
 
-    
-    @retry_count.times do
-    begin
-      response = http.request(request)	
-      case response.code
-	  
-	    # HTTP_SUCCESS :Code 2xx
-	    when HTTP_SUCCESS					
-	      puts "Event send to Loggly"
-		  
-		# HTTP_FORBIDDEN :Code 403
-	    when HTTP_FORBIDDEN					
-	      @logger.warn("User does not have privileges to execute the action.")
-		
-		# HTTP_NOT_FOUND :Code 404
-	    when HTTP_NOT_FOUND					
-	      @logger.warn("Invalid URL. Please check URL should be http://logs-01.loggly.com/inputs/CUSTOMER_TOKEN/tag/logstash")
-	    
-		# HTTP_INTERNAL_SERVER_ERROR :Code 500
-		when HTTP_INTERNAL_SERVER_ERROR			
-	      @logger.warn("Internal Server Error")
-		
-		# HTTP_GATEWAY_TIMEOUT :Code 504
-	    when HTTP_GATEWAY_TIMEOUT				
-	      @logger.warn("Gateway Time Out")
-	    else
-	      @logger.error("Unexpected response code", :code => response.code)
-      end # case
 
-      if [HTTP_SUCCESS,HTTP_FORBIDDEN,HTTP_NOT_FOUND].include?(response.code)	# break the retries loop for the specified response code
-        break
-      end
-	  rescue StandardError => e
+    @retry_count.times do
+      begin
+        response = http.request(request)
+        case response.code
+
+          # HTTP_SUCCESS :Code 2xx
+        when HTTP_SUCCESS
+          puts "Event send to Loggly"
+
+          # HTTP_FORBIDDEN :Code 403
+        when HTTP_FORBIDDEN
+          @logger.warn("User does not have privileges to execute the action.")
+
+          # HTTP_NOT_FOUND :Code 404
+        when HTTP_NOT_FOUND
+          @logger.warn("Invalid URL. Please check URL should be http://logs-01.loggly.com/inputs/CUSTOMER_TOKEN/tag/logstash")
+
+          # HTTP_INTERNAL_SERVER_ERROR :Code 500
+        when HTTP_INTERNAL_SERVER_ERROR
+          @logger.warn("Internal Server Error")
+
+          # HTTP_GATEWAY_TIMEOUT :Code 504
+        when HTTP_GATEWAY_TIMEOUT
+          @logger.warn("Gateway Time Out")
+        else
+          @logger.error("Unexpected response code", :code => response.code)
+        end # case
+
+        if [HTTP_SUCCESS,HTTP_FORBIDDEN,HTTP_NOT_FOUND].include?(response.code)	# break the retries loop for the specified response code
+          break
+        end
+      rescue StandardError => e
         @logger.error("An unexpected error occurred", :exception => e.class.name, :error => e.to_s, :backtrace => e.backtrace)
       end # rescue
-     
+
       if totalRetries < @retry_count && totalRetries > 0
         puts "Waiting for five seconds before retry..."
         sleep(5)
       end
-	  
+
       totalRetries = totalRetries + 1
     end #loop
   end # def send_event


### PR DESCRIPTION
* Update comment on how to get the proper key to send logs. It's the "Customer Token", not
  API Keys (which seem to fail silently).
* Specify `Content-Type`.
* Remove code comment that accidentally got into the very top of the plugin description
* Tone down the log noise: move a few to debug, replace `puts`es with the logger
* Fix a typo in a log message
* Whitespace cleanup

Closes #15, #17 and #23 