### PR TITLE
Dupe @timestamp to timestamp before sending to Loggly...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 4.1.0
+  - The plugin now sets field `timestamp` so that Loggly will recognize the
+    correct timestamp.
+    - The event's timestamps will however not be touched at all if `timestamp`
+      is already set on the event or if `@timestamp` is missing.
+  - This version introduces attribute `convert_timestamp` (default true), which
+    triggers the timestamp mingling.
+  - Now log a debug message with all of the plugin's configuration upon initialization.
+
 ## 4.0.0
   - The plugin now uses the Loggly bulk API.
   - If you need to modify event batch sizes and max delay between flushes,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
-## 4.1.0
-  - The plugin now sets field `timestamp` so that Loggly will recognize the
-    correct timestamp.
-    - The event's timestamps will however not be touched at all if `timestamp`
-      is already set on the event or if `@timestamp` is missing.
-  - This version introduces attribute `convert_timestamp` (default true), which
-    triggers the timestamp mingling.
+## 5.0.0
+  - This version introduces "breaking" changes for users who never copied/renamed
+    their `@timestamp` field to `timestamp`: their events will suddenly appear
+    in Loggly with a `timestamp` based on Logstash's value of `@timestamp`.
+    This would especially be noticed at times where processing is behind, and
+    events need to be "backfilled".
+    - The plugin now sets field `timestamp` so that Loggly will recognize the
+      correct timestamp.
+      - The event's timestamps will however not be touched at all if `timestamp`
+        is already set on the event or if `@timestamp` is missing.
+    - This version introduces attribute `convert_timestamp` (defaults to true), which
+      triggers the timestamp mingling.
   - Now log a debug message with all of the plugin's configuration upon initialization.
 
 ## 4.0.0

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -38,6 +38,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |=======================================================================
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-can_retry>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-convert_timestamp>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-host>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-key>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-max_event_size>> |<<bytes,bytes>>|Yes
@@ -57,13 +58,28 @@ output plugins.
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-can_retry"]
-===== `can_retry` 
+===== `can_retry`
 
   * Value type is <<boolean,boolean>>
   * Default value is `true`
 
 Can Retry.
 Setting this value true helps user to send multiple retry attempts if the first request fails
+
+[id="plugins-{type}s-{plugin}-convert_timestamp"]
+===== `convert_timestamp`
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `true`
+
+The plugin renames Logstash's '@timestamp' field to 'timestamp' before sending,
+so that Loggly recognizes it automatically.
+
+This will do nothing if your event doesn't have a '@timestamp' field or if
+your event already has a 'timestamp' field.
+
+Note that the actual Logstash event is not modified by the output. This modification
+only happens on a copy of the event, prior to sending.
 
 [id="plugins-{type}s-{plugin}-host"]
 ===== `host`

--- a/lib/logstash/outputs/loggly.rb
+++ b/lib/logstash/outputs/loggly.rb
@@ -36,6 +36,9 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
   #
   # This will do nothing if your event doesn't have a '@timestamp' field or if
   # your event already has a 'timestamp' field.
+  #
+  # Note that the actual Logstash event is not modified by the output. This
+  # modification only happens on a copy of the event, prior to sending.
   config :convert_timestamp, :validate => :boolean, :default => true
 
   # The hostname to send logs to. This should target the loggly http input

--- a/lib/logstash/outputs/loggly.rb
+++ b/lib/logstash/outputs/loggly.rb
@@ -113,6 +113,7 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
 
   public
   def register
+    @logger.debug "Initializing Loggly Output", @config
   end
 
   public

--- a/logstash-output-loggly.gemspec
+++ b/logstash-output-loggly.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'logstash-codec-plain'
+  s.add_development_dependency 'rake', '~> 12.2.1' # for JRuby 1.7, Ruby 1.9
 end
 

--- a/logstash-output-loggly.gemspec
+++ b/logstash-output-loggly.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-loggly'
-  s.version         = '4.1.0'
+  s.version         = '5.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Ships logs to Loggly"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-output-loggly.gemspec
+++ b/logstash-output-loggly.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-loggly'
-  s.version         = '4.0.0'
+  s.version         = '4.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Ships logs to Loggly"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/loggly_spec.rb
+++ b/spec/outputs/loggly_spec.rb
@@ -7,7 +7,7 @@ def logger_for(plugin)
 end
 
 describe 'outputs/loggly' do
-  let(:config) { { 'key' => 'abcdef123456' } }
+  let(:config) { { 'key' => 'abcdef123456', 'convert_timestamp' => false } }
 
   let(:output) do
     LogStash::Outputs::Loggly.new(config).tap do |output|
@@ -41,7 +41,7 @@ describe 'outputs/loggly' do
 
   context 'when sending events' do
     it 'should set the default tag to logstash' do
-      expect(output).to receive(:send_batch).with([{event: event, key: 'abcdef123456', tag: 'logstash'}])
+      expect(output).to receive(:send_batch).with([{event: event.to_hash, key: 'abcdef123456', tag: 'logstash'}])
       output.receive(event)
     end
 
@@ -50,19 +50,19 @@ describe 'outputs/loggly' do
       event.set('token', 'xxxxxxx1234567')
       config['key'] = '%{token}'
 
-      expect(output).to receive(:send_batch).with([{event: event, key: 'xxxxxxx1234567', tag: 'logstash'}])
+      expect(output).to receive(:send_batch).with([{event: event.to_hash, key: 'xxxxxxx1234567', tag: 'logstash'}])
       output.receive(event)
     end
 
     it 'should support field interpolation for tag' do
       config['tag'] = '%{source}'
-      expect(output).to receive(:send_batch).with([{event: event, key: 'abcdef123456', tag: 'someapp'}])
+      expect(output).to receive(:send_batch).with([{event: event.to_hash, key: 'abcdef123456', tag: 'someapp'}])
       output.receive(event)
     end
 
     it 'should default tag to logstash if interpolated field for tag does not exist' do
       config['tag'] = '%{foobar}'
-      expect(output).to receive(:send_batch).with([{event: event, key: 'abcdef123456', tag: 'logstash'}])
+      expect(output).to receive(:send_batch).with([{event: event.to_hash, key: 'abcdef123456', tag: 'logstash'}])
       output.receive(event)
     end
 
@@ -72,7 +72,7 @@ describe 'outputs/loggly' do
       event2 = event.clone
       event2.remove('custom_key')
 
-      expect(output).to receive(:send_batch).once.with([{event: event, key: 'a_key', tag: 'logstash'}, nil])
+      expect(output).to receive(:send_batch).once.with([{event: event.to_hash, key: 'a_key', tag: 'logstash'}, nil])
       logger = logger_for(output)
       expect(logger).to receive(:warn).with(/No key provided/)
       expect(logger).to receive(:debug).with(/Dropped message/, kind_of(Hash))


### PR DESCRIPTION
Dupe @timestamp to timestamp before sending to Loggly, then remove the timestamp field after sending, to leave the event unmodified for other outputs in the pipeline.

- [x] Rebase/reimplement this on top of the bulk API pull request after it lands
- [x] Change the version bump

Questions

- See below, comment about default value for `convert_timestamp`.

Closes #12, closes #19 