### PR TITLE
Move to the bulk API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 4.0.0
+  - The plugin now uses the Loggly bulk API.
+  - If you need to modify event batch sizes and max delay between flushes,
+    please adjust the Logstash settings `pipeline.batch.size` and
+    `pipeline.batch.delay` respectively.
+  - New settings: `max_event_size` and `max_payload_size`.
+    Both are currently set according to Loggly's [published API limits](https://www.loggly.com/docs/http-bulk-endpoint/).
+    They only need to be changed if Loggly changes these limits.
+  - The plugin now skips events bigger than the API limit for single event size.
+    A proper warning is logged when this happens.
+  - When interpolating `key` field, drop messages where interpolation doesn't
+    resolve (meaning we don't have the API key for the event).
+  - When interpolating `tag` field, revert to default of 'logstash' if interpolation doesn't resolve.
+  - Beef up unit tests significantly.
+  - See pull request [#29](https://github.com/logstash-plugins/logstash-output-loggly/pull/29) for all details.
+
 ## 3.0.5
   - [#24](https://github.com/logstash-plugins/logstash-output-loggly/pull/24)
     Get rid of a Ruby warning from using `timeout`.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -40,6 +40,8 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-can_retry>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-host>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-key>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-max_event_size>> |<<bytes,bytes>>|Yes
+| <<plugins-{type}s-{plugin}-max_payload_size>> |<<bytes,bytes>>|Yes
 | <<plugins-{type}s-{plugin}-proto>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-proxy_host>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-proxy_password>> |<<password,password>>|No
@@ -64,15 +66,15 @@ Can Retry.
 Setting this value true helps user to send multiple retry attempts if the first request fails
 
 [id="plugins-{type}s-{plugin}-host"]
-===== `host` 
+===== `host`
 
   * Value type is <<string,string>>
   * Default value is `"logs-01.loggly.com"`
 
 The hostname to send logs to. This should target the loggly http input
 server which is usually "logs-01.loggly.com" (Gen2 account).
-See Loggly HTTP endpoint documentation at
-https://www.loggly.com/docs/http-endpoint/
+See the https://www.loggly.com/docs/http-endpoint/[Loggly HTTP endpoint documentation].
+
 
 [id="plugins-{type}s-{plugin}-key"]
 ===== `key` 
@@ -87,6 +89,34 @@ You can find yours in "Source Setup", under "Customer Tokens".
 You can use `%{foo}` field lookups here if you need to pull the api key from
 the event. This is mainly aimed at multitenant hosting providers who want
 to offer shipping a customer's logs to that customer's loggly account.
+
+[id="plugins-{type}s-{plugin}-max_event_size"]
+===== `max_event_size`
+
+  * This is a required setting.
+  * Value type is <<bytes,bytes>>
+  * Default value is 1 Mib
+
+The Loggly API supports event size up to 1 Mib.
+
+You should only need to change this setting if the
+API limits have changed and you need to override the plugin's behaviour.
+
+See the https://www.loggly.com/docs/http-bulk-endpoint/[Loggly bulk API documentation]
+
+[id="plugins-{type}s-{plugin}-max_payload_size"]
+===== `max_payload_size`
+
+  * This is a required setting.
+  * Value type is <<bytes,bytes>>
+  * Default value is 5 Mib
+
+The Loggly API supports API call payloads up to 5 Mib.
+
+You should only need to change this setting if the
+API limits have changed and you need to override the plugin's behaviour.
+
+See the https://www.loggly.com/docs/http-bulk-endpoint/[Loggly bulk API documentation]
 
 [id="plugins-{type}s-{plugin}-proto"]
 ===== `proto` 
@@ -145,14 +175,15 @@ It will try to submit request until retry_count and then halt
   * Value type is <<string,string>>
   * Default value is `"logstash"`
 
-Loggly Tag
-Tag helps you to find your logs in the Loggly dashboard easily
-You can make a search in Loggly using tag as "tag:logstash-contrib"
-or the tag set by you in the config file.
+Loggly Tags help you to find your logs in the Loggly dashboard easily.
+You can search for a tag in Loggly using `"tag:logstash"`.
 
-You can use %{somefield} to allow for custom tag values.
-Helpful for leveraging Loggly source groups.
-https://www.loggly.com/docs/source-groups/
+If you need to specify multiple tags here on your events,
+specify them as outlined in https://www.loggly.com/docs/tags/[the tag documentation].
+E.g. `"tag" => "foo,bar,myApp"`.
+
+You can also use `"tag" => "%{somefield}"` to take your tag value from `somefield` on your event.
+Helpful for leveraging https://www.loggly.com/docs/source-groups/[Loggly source groups].
 
 
 

--- a/lib/logstash/outputs/loggly.rb
+++ b/lib/logstash/outputs/loggly.rb
@@ -2,6 +2,7 @@
 require "logstash/outputs/base"
 require "logstash/namespace"
 require "timeout"
+require "stud/buffer"
 require "uri"
 # TODO(sissel): Move to something that performs better than net/http
 require "net/http"
@@ -27,6 +28,8 @@ end
 # To use this, you'll need to use a Loggly input with type 'http'
 # and 'json logging' enabled.
 class LogStash::Outputs::Loggly < LogStash::Outputs::Base
+  include Stud::Buffer
+
   config_name "loggly"
 
   # The hostname to send logs to. This should target the loggly http input
@@ -56,7 +59,7 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
   # https://www.loggly.com/docs/source-groups/
   config :tag, :validate => :string, :default => "logstash"
 
-  # Retry count. 
+  # Retry count.
   # It may be possible that the request may timeout due to slow Internet connection
   # if such condition appears, retry_count helps in retrying request for multiple times
   # It will try to submit request until retry_count and then halt
@@ -78,6 +81,23 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
   # Proxy Password
   config :proxy_password, :validate => :password, :default => ""
 
+  # This plugin uses the bulk index api for improved indexing performance.
+  # To make efficient bulk api calls, we will buffer a certain number of
+  # events before flushing that out to Loggly. This setting
+  # controls how many events will be buffered before sending a batch
+  # of events.
+  config :flush_size, :validate => :number, :default => 100
+
+  # The amount of time since last flush before a flush is forced.
+  #
+  # This setting helps ensure slow event rates don't get stuck in Logstash.
+  # For example, if your `flush_size` is 100, and you have received 10 events,
+  # and it has been more than `idle_flush_time` seconds since the last flush,
+  # logstash will flush those 10 events automatically.
+  #
+  # This helps keep both fast and slow log streams moving along in
+  # near-real-time.
+  config :idle_flush_time, :validate => :number, :default => 1
 
   # HTTP constants
   HTTP_SUCCESS = "200"
@@ -88,11 +108,16 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
 
   public
   def register
-    # nothing to do
+    buffer_initialize(
+      :max_items => @flush_size,
+      :max_interval => @idle_flush_time,
+      :logger => @logger
+    )
   end
 
   public
   def receive(event)
+    return unless output?(event)
     key = event.sprintf(@key)
     tag = event.sprintf(@tag)
 
@@ -100,14 +125,25 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
     # we should ship logs with the default tag value.
     tag = 'logstash' if /^%{\w+}/.match(tag)
 
-    # Send event
-    send_event("#{@proto}://#{@host}/inputs/#{key}/tag/#{tag}", format_message(event))
+    buffer_receive([event, key, tag])
   end # def receive
 
   public
   def format_message(event)
     event.to_json
   end
+
+  def flush(events, close=false)
+    # Avoid creating a new string for newline every time
+    newline = "\n".freeze
+
+    body = events.collect do |event, key, tag|
+      [ format_message(event), newline ]
+    end.flatten
+
+    send_event("#{@proto}://#{@host}/bulk/#{@key}/tag/#{@tag}", body.join(""))
+  end # def receive_bulk
+
 
   private
   def send_event(url, message)
@@ -141,32 +177,33 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
         response = http.request(request)
         case response.code
 
-          # HTTP_SUCCESS :Code 2xx
+        # HTTP_SUCCESS :Code 2xx
         when HTTP_SUCCESS
           @logger.debug("Event sent to Loggly")
 
-          # HTTP_FORBIDDEN :Code 403
+        # HTTP_FORBIDDEN :Code 403
         when HTTP_FORBIDDEN
           @logger.warn("User does not have privileges to execute the action.")
 
-          # HTTP_NOT_FOUND :Code 404
+        # HTTP_NOT_FOUND :Code 404
         when HTTP_NOT_FOUND
           @logger.warn("Invalid URL. Please check URL should be http://logs-01.loggly.com/inputs/CUSTOMER_TOKEN/tag/logstash")
 
-          # HTTP_INTERNAL_SERVER_ERROR :Code 500
+        # HTTP_INTERNAL_SERVER_ERROR :Code 500
         when HTTP_INTERNAL_SERVER_ERROR
           @logger.warn("Internal Server Error")
 
-          # HTTP_GATEWAY_TIMEOUT :Code 504
+        # HTTP_GATEWAY_TIMEOUT :Code 504
         when HTTP_GATEWAY_TIMEOUT
           @logger.warn("Gateway Time Out")
         else
           @logger.error("Unexpected response code", :code => response.code)
         end # case
 
-        if [HTTP_SUCCESS,HTTP_FORBIDDEN,HTTP_NOT_FOUND].include?(response.code)	# break the retries loop for the specified response code
+        if [HTTP_SUCCESS,HTTP_FORBIDDEN,HTTP_NOT_FOUND].include?(response.code)   # break the retries loop for the specified response code
           break
         end
+
       rescue StandardError => e
         @logger.error("An unexpected error occurred", :exception => e.class.name, :error => e.to_s, :backtrace => e.backtrace)
       end # rescue
@@ -179,4 +216,9 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
       totalRetries = totalRetries + 1
     end #loop
   end # def send_event
+
+  def close
+    buffer_flush(:final => true)
+  end # def close
+
 end # class LogStash::Outputs::Loggly

--- a/logstash-output-loggly.gemspec
+++ b/logstash-output-loggly.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-loggly'
-  s.version         = '3.0.5'
+  s.version         = '4.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Ships logs to Loggly"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/loggly_spec.rb
+++ b/spec/outputs/loggly_spec.rb
@@ -2,12 +2,22 @@
 require 'logstash/devutils/rspec/spec_helper'
 require 'logstash/outputs/loggly'
 
+def logger_for(plugin)
+  plugin.instance_variable_get('@logger')
+end
+
 describe 'outputs/loggly' do
   let(:config) { { 'key' => 'abcdef123456' } }
 
+  let(:output) do
+    LogStash::Outputs::Loggly.new(config).tap do |output|
+      output.register
+    end
+  end
+
   let(:event) do
     LogStash::Event.new(
-      'message' => 'fanastic log entry',
+      'message' => 'fantastic log entry',
       'source' => 'someapp',
       'type' => 'nginx',
       '@timestamp' => LogStash::Timestamp.now)
@@ -21,45 +31,168 @@ describe 'outputs/loggly' do
     end
 
     it 'should have default config values' do
-      insist { subject.proto } == 'http'
-      insist { subject.host } == 'logs-01.loggly.com'
-      insist { subject.tag } == 'logstash'
+      expect(subject.proto).to eq('http')
+      expect(subject.host).to eq('logs-01.loggly.com')
+      expect(subject.tag).to eq('logstash')
+      expect(subject.max_event_size).to eq(1_048_576)
+      expect(subject.max_payload_size).to eq(5_242_880)
     end
   end
 
-  context 'when outputting messages' do
+  context 'when sending events' do
+    it 'should set the default tag to logstash' do
+      expect(output).to receive(:send_batch).with([{event: event, key: 'abcdef123456', tag: 'logstash'}])
+      output.receive(event)
+    end
+
     it 'should support field interpolation on key' do
       # add a custom key value for Loggly config
       event.set('token', 'xxxxxxx1234567')
       config['key'] = '%{token}'
 
-      output = LogStash::Outputs::Loggly.new(config)
-      allow(output).to receive(:send_event).with('http://logs-01.loggly.com/inputs/xxxxxxx1234567/tag/logstash',
-                                                 event.to_json)
-      output.receive(event)
-    end
-
-    it 'should set the default tag to logstash' do
-      output = LogStash::Outputs::Loggly.new(config)
-      allow(output).to receive(:send_event).with('http://logs-01.loggly.com/inputs/abcdef123456/tag/logstash',
-                                                 event.to_json)
+      expect(output).to receive(:send_batch).with([{event: event, key: 'xxxxxxx1234567', tag: 'logstash'}])
       output.receive(event)
     end
 
     it 'should support field interpolation for tag' do
       config['tag'] = '%{source}'
-      output = LogStash::Outputs::Loggly.new(config)
-      allow(output).to receive(:send_event).with('http://logs-01.loggly.com/inputs/abcdef123456/tag/someapp',
-                                                 event.to_json)
+      expect(output).to receive(:send_batch).with([{event: event, key: 'abcdef123456', tag: 'someapp'}])
       output.receive(event)
     end
 
-    it 'should default tag to logstash if interpolated field does not exist' do
+    it 'should default tag to logstash if interpolated field for tag does not exist' do
       config['tag'] = '%{foobar}'
-      output = LogStash::Outputs::Loggly.new(config)
-      allow(output).to receive(:send_event).with('http://logs-01.loggly.com/inputs/abcdef123456/tag/logstash',
-                                                 event.to_json)
+      expect(output).to receive(:send_batch).with([{event: event, key: 'abcdef123456', tag: 'logstash'}])
       output.receive(event)
+    end
+
+    it 'should drop messages where interpolated field for key does not exist' do
+      config['key'] = '%{custom_key}'
+      event.set('custom_key', 'a_key')
+      event2 = event.clone
+      event2.remove('custom_key')
+
+      expect(output).to receive(:send_batch).once.with([{event: event, key: 'a_key', tag: 'logstash'}, nil])
+      logger = logger_for(output)
+      expect(logger).to receive(:warn).with(/No key provided/)
+      expect(logger).to receive(:debug).with(/Dropped message/, kind_of(Hash))
+
+      output.multi_receive([event, event2])
+    end
+
+    context 'with different combinations of key and tag' do
+      it 'should perform one http request per batch of common key+tag' do
+        config['key'] = '%{custom_key}'
+        config['tag'] = '%{custom_tag}'
+        event.set('custom_key', 'generally_used_key')
+
+        event1 = event.clone.tap { |e| e.set('message', 'event1') }
+        event2 = event.clone.tap { |e| e.set('message', 'event2') ; e.set('custom_key', 'other_key') }
+        event3 = event.clone.tap { |e| e.set('message', 'event3') ; e.set('custom_tag', 'other_tag') }
+        event4 = event.clone.tap { |e| e.set('message', 'event4') }
+
+        expect(output).to receive(:perform_api_call) { |url, body|
+          expect(body).to match /"event1"/
+          expect(body).to match /"event4"/
+          expect(url).to eq('http://logs-01.loggly.com/bulk/generally_used_key/tag/logstash')
+        }
+        expect(output).to receive(:perform_api_call) { |url, body|
+          expect(body).to match /"event2"/
+          expect(url).to eq('http://logs-01.loggly.com/bulk/other_key/tag/logstash')
+        }
+        expect(output).to receive(:perform_api_call) { |url, body|
+          expect(body).to match /"event3"/
+          expect(url).to eq('http://logs-01.loggly.com/bulk/generally_used_key/tag/other_tag')
+        }
+        expect(output).not_to receive(:perform_api_call) # anymore
+
+        output.multi_receive([event1, event2, event3, event4])
+      end
+    end
+  end
+
+  context 'splitting batches of events' do
+    context 'when they are all with the same key+tag' do
+      it 'should return one batch' do
+        batches = output.split_batches([ {event: :event1, key: 'key1', tag: 'tag1'},
+                                         {event: :event2, key: 'key1', tag: 'tag1'} ])
+        expect(batches.size).to eq(1)
+        expect(batches).to eq({ ['key1', 'tag1'] => [:event1, :event2] })
+      end
+    end
+
+    context 'when messages have different key & tag' do
+      it 'should return one batch for each key+tag combination' do
+        batches = output.split_batches([
+          {event: :event1, key: 'key1', tag: 'tag1'},
+          {event: :event2, key: 'key2', tag: 'tag1'},
+          {event: :event3, key: 'key2', tag: 'tag2'},
+          {event: :event4, key: 'key1', tag: 'tag1'},
+          {event: :event5, key: 'key2', tag: 'tag1'},
+          {event: :event6, key: 'key1', tag: 'tag1'},
+          {event: :event7, key: 'key1', tag: 'tag1'},
+        ])
+        expect(batches.size).to eq(3)
+        expect(batches).to eq(
+          { ['key1', 'tag1'] => [:event1, :event4, :event6, :event7],
+            ['key2', 'tag1'] => [:event2, :event5],
+            ['key2', 'tag2'] => [:event3],
+          })
+      end
+    end
+  end
+
+  context 'when building message bodies' do
+    it 'should send only one payload when everything fits' do
+      yielded_times = 0
+      output.build_message_bodies([event] * 10) do |body|
+        expect(body.lines.count).to eq(10)
+
+        yielded_times += 1
+      end
+      expect(yielded_times).to eq(1)
+    end
+
+    it 'should skip events that are bigger than max_event_size' do
+      config['max_event_size'] = 1024
+      good_event = LogStash::Event.new('message' => 'fantastic log entry',
+                                       'source' => 'someapp',
+                                       'type' => 'nginx',
+                                       '@timestamp' => LogStash::Timestamp.now)
+      big_event = good_event.clone.tap { |e| e.set('filler', 'helloworld' * 100) }
+
+      logger = logger_for output
+      expect(logger).to receive(:warn).once.with(
+        /Skipping event/, hash_including(:event_size => 1134,
+                                         :max_event_size => 1024))
+      expect(logger).to receive(:debug).twice
+
+      yielded_times = 0
+      output.build_message_bodies([good_event, big_event]) do |body|
+        expect(body.lines.count).to eq(1)
+        expect(body).not_to match /helloworld/
+
+        yielded_times += 1
+      end
+      expect(yielded_times).to eq(1)
+    end
+
+    it 'should yield as many times as needed to send appropriately-sized payloads' do
+      config['max_payload_size'] = 1024
+      # Once JSON-encoded, these events are 122 bytes each.
+      # 8 of them fit in a 1024 bytes payload
+      event = LogStash::Event.new('message' => 'fantastic log entry',
+                                  'source' => 'someapp',
+                                  'type' => 'nginx',
+                                  '@timestamp' => LogStash::Timestamp.now)
+
+      payloads = []
+      output.build_message_bodies([event] * 10) do |body|
+        payloads << body
+      end
+      expect(payloads.size).to eq(2)
+      expect(payloads[0].lines.count).to eq(8)
+      expect(payloads[1].lines.count).to eq(2)
     end
   end
 end


### PR DESCRIPTION
A quick test sending 1000 events with 3.0.5 vs the bulk API was obviously very
convincing. 3.0.5 took 1m12s while this version took 3s.

Missing:

- [x] Spec are only `allow`ing a call to be made to send_event (which as of #18  isn't happening anymore, but they don't fail). Must move this to `expect`.
- [x] Make the flush respect each event's potential custom `key` and `tag`
- [x] Make the buffering code easier to test
- [x] Add tests specific to the buffering.
- [x] Log warning and drop messages where the interpolated key field doesn't get set
- [x] Version bump to 3.1.0, this is a significant (but backwards compatible) change.

1st round of feedback

- [x] Dropped message only in debug, and pass event as a separate field
- [x] Replace the queueing in the plugin by `multi_receive` & appropriate instructions to use the Logstash persistent queue
- [x] Open an issue about replacing the retries with the DLQ: #30 
- [x] Repurpose `flush_size` to cap the size of API calls.

2nd round of feedback

- [x] Remove `flush_size` and split payload before we hit the API limit of 5Mb per API call
- [x] Drop events that go above 1Mb, log a warning
- [x] Add settings for max event size and max payload size & document these two size limits with appropriate links to the canonical doc.
- [x] Remove the `to_hash`. Try to keep with `Event` until it's time to convert to JSON.
- [x] Mention that batch size and max flush intervals are now handled at the Logstash pipeline level, for users who want to tweak them.
- [x] Review the changelog wrt latest developments

Discarded ideas:

- The Loggly API [does not return 413 entity too large](https://www.loggly.com/docs/api-overview/), when either one message or a full payload go over their respective size limit. Instead it returns 200 ok and doesn't ingest the event. So there's no need to check for 413.

Closes #18, closes #14, closes #22