### PR TITLE
fixed bug with tag setting

### DIFF
--- a/lib/logstash/outputs/loggly.rb
+++ b/lib/logstash/outputs/loggly.rb
@@ -142,7 +142,7 @@ class LogStash::Outputs::Loggly < LogStash::Outputs::Base
     tags.each do |t|
       t = event.sprintf(t)
       # For those cases where %{somefield} doesn't exist we don't include it
-      unless /%{\w+}/.match(t) || t.blank?
+      unless /%{\w+}/.match(t) || t.empty?
         tag_array.push(t)
       end
     end


### PR DESCRIPTION
This PR fixes a bug where setting the tag attribute for the output plugin raised an exception. The behavior is documented in this issue #33 .
